### PR TITLE
Internet Explorer 11 Fix for pointer-events

### DIFF
--- a/src/mapScrollPrevent.js
+++ b/src/mapScrollPrevent.js
@@ -86,7 +86,7 @@ jQuery.fn.extend({
     // Overlay functions
     hideOverlay = function()
     {
-      iframeObject.css({ "pointer-events":"initial" });
+      iframeObject.css({ "pointer-events":"auto" });
       $(this).fadeOut();
     };
     showOverlay = function()


### PR DESCRIPTION
Change "initial" to "auto" for “pointer-events” value to restore
default functionality based on the information at
https://css-tricks.com/almanac/properties/p/pointer-events/.

This resolves the problem where links were not clickable in Internet
Explorer 11 even though they worked in Safari, Chrome, Firefox, IE9 and
IE10.
